### PR TITLE
Resolve exception caused in O4_Mesh_Utils.py by calling exit_message_…

### DIFF
--- a/src/O4_Mesh_Utils.py
+++ b/src/O4_Mesh_Utils.py
@@ -287,7 +287,7 @@ def build_mesh(tile):
     alt_file     = FNAMES.alt_file(tile)
     weight_file  = FNAMES.weight_file(tile)
     if not os.path.isfile(poly_file):
-        UI.exit_message_and_bottom_line("\nERROR: Could not find ",poly_file)
+        UI.exit_message_and_bottom_line("\nERROR: Could not find "+poly_file)
         return 0
     
     tile.ensure_elevation_data()


### PR DESCRIPTION
…and_bottom_line with excess parameters

This appends the poly_file to the error string, rather than passing it as another parameter.  Now it will appear in the main window UI instead of raising an exception.
