### PR TITLE
Fix some issues around earth window batch processing

### DIFF
--- a/src/O4_Config_Utils.py
+++ b/src/O4_Config_Utils.py
@@ -172,9 +172,13 @@ class Tile():
                     # compatibility with config files from version <= 1.20
                     if value and value[0] in ('"',"'"): value=value[1:]
                     if value and value[-1] in ('"',"'"): value=value[:-1]
-                    exec("self."+var+"=cfg_vars['"+var+"'](value)")
+                    if cfg_vars[var]['type'] in (bool,list):
+                        cmd="self."+var+"="+value
+                    else:
+                        cmd="self."+var+"=cfg_vars['"+var+"']['type'](value)"
+                    exec(cmd)
                 except Exception as e:
-                    UI.vrpint(2,e)
+                    UI.lvprint(2,e)
                     pass
             f.close()
             return 1


### PR DESCRIPTION
There were a few troubles reading the per-tile config file from the batch processing mode in the earth window.  This fixes a data type on one of the attributes, a function name typo, and handling of list types on load.

It appears to work in my testing so far, but the code could use a review / sanity check from someone who understands it better than I do, before being merged.
