### PR TITLE
Enable vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ubuntu-xenial-16.04-cloudimg-console.log
+.vagrant/

--- a/Ortho4XP_App.desktop
+++ b/Ortho4XP_App.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.30
+Name=Ortho4XP
+Comment=This is Ortho4XP v1.30
+Exec=Ortho4XP_starter
+Icon=/usr/share/pixmaps/python3.xpm
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=Utility;Application;

--- a/Ortho4XP_fixvbguest.desktop
+++ b/Ortho4XP_fixvbguest.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Fix_VBox
+Comment="This is a fix for vbguest additions"
+Exec=/vagrant/Ortho4XP_vboxguestadditions.sh
+Icon=/usr/share/pixmaps/python3.xpm
+Terminal=true
+Type=Application
+Categories=Utility;Application;

--- a/Ortho4XP_provision_script.sh
+++ b/Ortho4XP_provision_script.sh
@@ -17,7 +17,12 @@ apt-get install -y python3 \
     python3-pil.imagetk \
     p7zip-full
 
-# Uncomment the line below only if you have turned on the GUI on the Vagrantfile
-# apt-get install -y ubuntu-desktop
+# Comment this line below if you want to have headless Ubuntu
+apt-get install -y ubuntu-desktop
 
 apt-get -y update
+
+chmod a+x /vagrant/Ortho4XP_starter.sh
+chmod a+x /vagrant/Ortho4XP_vboxguestadditions.sh
+
+ln -s /vagrant/Ortho4XP_starter.sh /usr/local/bin/Ortho4XP_starter

--- a/Ortho4XP_provision_script.sh
+++ b/Ortho4XP_provision_script.sh
@@ -33,11 +33,13 @@ chmod a+x $Ortho4XP_VB_Fix
 
 starter=/usr/local/bin/Ortho4XP_starter
 local_app_dir=/home/vagrant/.local/share/applications
-Ortho4XP_App_local="$local_app_dir/Ortho4XP_App.desktop"
-Ortho4XP_fixvbguest="$local_app_dir/Ortho4XP_fixvbguest.desktop"
+desktop_dir=/home/vagrant/Desktop
 
-Ortho4XP_App_Desktop=/home/vagrant/Desktop/Ortho4XP.desktop
-Ortho4XP_fixvbguest_Desktop=/home/vagrant/Desktop/Fix_VB.desktop
+Ortho4XP_App_local="$local_app_dir/Ortho4XP_App.desktop"
+Ortho4XP_fixvbguest_local="$local_app_dir/Ortho4XP_fixvbguest.desktop"
+
+Ortho4XP_App_Desktop="$desktop_dir/Ortho4XP.desktop"
+Ortho4XP_fixvbguest_Desktop="$desktop_dir/Fix_VB.desktop"
 
 if [ ! -L $starter ]; then
   ln -s /vagrant/Ortho4XP_starter.sh $starter
@@ -45,20 +47,21 @@ fi
 
 if [ ! -L $local_app_dir ]; then
   mkdir -p $local_app_dir
+  mkdir -p $desktop_dir
 fi
 
 if [ ! -L $Ortho4XP_App_local ]; then
-  cp /vagrant/Ortho4XP_App.desktop $Ortho4XP_App_local
+  cp $Ortho4XP_App $Ortho4XP_App_local
 
   if [ ! -L $Ortho4XP_App_Desktop ]; then
     ln -s $Ortho4XP_App_local $Ortho4XP_App_Desktop
   fi
 fi
 
-if [ ! -L $Ortho4XP_fixvbguest ]; then
-  cp /vagrant/Ortho4XP_fixvbguest.desktop $Ortho4XP_fixvbguest
+if [ ! -L $Ortho4XP_fixvbguest_local ]; then
+  cp $Ortho4XP_VB_Fix $Ortho4XP_fixvbguest_local
 
   if [ ! -L $Ortho4XP_fixvbguest_Desktop ]; then
-    ln -s $Ortho4XP_fixvbguest $Ortho4XP_fixvbguest_Desktop
+    ln -s $Ortho4XP_fixvbguest_local $Ortho4XP_fixvbguest_Desktop
   fi
 fi

--- a/Ortho4XP_provision_script.sh
+++ b/Ortho4XP_provision_script.sh
@@ -25,4 +25,40 @@ apt-get -y update
 chmod a+x /vagrant/Ortho4XP_starter.sh
 chmod a+x /vagrant/Ortho4XP_vboxguestadditions.sh
 
-ln -s /vagrant/Ortho4XP_starter.sh /usr/local/bin/Ortho4XP_starter
+Ortho4XP_App=/vagrant/Ortho4XP_App.desktop
+Ortho4XP_VB_Fix=/vagrant/Ortho4XP_fixvbguest.desktop
+
+chmod a+x $Ortho4XP_App
+chmod a+x $Ortho4XP_VB_Fix
+
+starter=/usr/local/bin/Ortho4XP_starter
+local_app_dir=/home/vagrant/.local/share/applications
+Ortho4XP_App_local="$local_app_dir/Ortho4XP_App.desktop"
+Ortho4XP_fixvbguest="$local_app_dir/Ortho4XP_fixvbguest.desktop"
+
+Ortho4XP_App_Desktop=/home/vagrant/Desktop/Ortho4XP.desktop
+Ortho4XP_fixvbguest_Desktop=/home/vagrant/Desktop/Fix_VB.desktop
+
+if [ ! -L $starter ]; then
+  ln -s /vagrant/Ortho4XP_starter.sh $starter
+fi
+
+if [ ! -L $local_app_dir ]; then
+  mkdir -p $local_app_dir
+fi
+
+if [ ! -L $Ortho4XP_App_local ]; then
+  cp /vagrant/Ortho4XP_App.desktop $Ortho4XP_App_local
+
+  if [ ! -L $Ortho4XP_App_Desktop ]; then
+    ln -s $Ortho4XP_App_local $Ortho4XP_App_Desktop
+  fi
+fi
+
+if [ ! -L $Ortho4XP_fixvbguest ]; then
+  cp /vagrant/Ortho4XP_fixvbguest.desktop $Ortho4XP_fixvbguest
+
+  if [ ! -L $Ortho4XP_fixvbguest_Desktop ]; then
+    ln -s $Ortho4XP_fixvbguest $Ortho4XP_fixvbguest_Desktop
+  fi
+fi

--- a/Ortho4XP_provision_script.sh
+++ b/Ortho4XP_provision_script.sh
@@ -22,6 +22,8 @@ apt-get install -y ubuntu-desktop
 
 apt-get -y update
 
+sed -i -e 's/\r$//' /vagrant/Ortho4XP_starter.sh /vagrant/Ortho4XP_provision_script.sh /vagrant/Ortho4XP_vboxguestadditions.sh
+
 chmod a+x /vagrant/Ortho4XP_starter.sh
 chmod a+x /vagrant/Ortho4XP_vboxguestadditions.sh
 

--- a/Ortho4XP_starter.sh
+++ b/Ortho4XP_starter.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /vagrant
+
+python3 Ortho4XP_v130.py

--- a/Ortho4XP_vboxguestadditions.sh
+++ b/Ortho4XP_vboxguestadditions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+sudo mount /dev/cdrom /mnt
+
+cd /mnt
+
+sudo ./VBoxLinuxAdditions.run

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provision :shell, path: "provision_script.sh"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         "--medium", "emptydrive"]
   end
 
+  config.vm.synced_folder "./", "/vagrant", owner: "vagrant", group: "vagrant", mount_options: ["dmode=775,fmode=775"]
+
   config.vm.provision "shell", inline: <<-SCRIPT
 echo "Updating ubuntu password"
 echo "ubuntu:ubuntu" | chpasswd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,12 +8,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider "virtualbox" do |v|
-    # v.gui = true should be commented out by default, because headless connection is way faster.
-    # If you still wanna use the Ortho4XP GUI, please uncomment the line below `v.gui = true` by removing the #
-    # Please remember to uncomment the ubuntu-desktop installation command in provision_script.sh as well
+    # comment v.gui = true to get headless Ubuntu which is way faster.
 
-    # v.gui = true
+    v.gui = true
     v.customize ["modifyvm", :id, "--memory", "2048"]
+    v.customize ["modifyvm", :id, "--vram", "128"]
   end
 
   config.vm.provision "shell", inline: <<-SCRIPT
@@ -21,5 +20,5 @@ echo "Updating ubuntu password"
 echo "ubuntu:ubuntu" | chpasswd
 SCRIPT
 
-  config.vm.provision :shell, path: "provision_script.sh"
+  config.vm.provision :shell, path: "Ortho4XP_provision_script.sh"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.gui = true
     v.customize ["modifyvm", :id, "--memory", "2048"]
     v.customize ["modifyvm", :id, "--vram", "128"]
+    v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+    v.customize ["storageattach", :id,
+        "--storagectl", "IDE",
+        "--port", "0",
+        "--device", "1",
+        "--type", "dvddrive",
+        "--medium", "emptydrive"]
   end
 
   config.vm.provision "shell", inline: <<-SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider "virtualbox" do |v|
-    v.gui = true
+    # v.gui = true should be commented out by default, because headless connection is way faster.
+    # If you still wanna use the Ortho4XP GUI, please uncomment the line below `v.gui = true` by removing the #
+    # Please remember to uncomment the ubuntu-desktop installation command in provision_script.sh as well
+
+    # v.gui = true
+    v.customize ["modifyvm", :id, "--memory", "2048"]
   end
+
+  config.vm.provision "shell", inline: <<-SCRIPT
+echo "Updating ubuntu password"
+echo "ubuntu:ubuntu" | chpasswd
+SCRIPT
 
   config.vm.provision :shell, path: "provision_script.sh"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.synced_folder "./", "/vagrant", owner: "vagrant", group: "vagrant", mount_options: ["dmode=775,fmode=775"]
 
+  ###########################################
+  # Enable the synced_folder based on your OS.
+
+  # 1. Enable the line below and update the path to point your X-Plane 11 path in Mac. This is to allow selecting overlay folder.
+  # config.vm.synced_folder "/Users/yamin/Desktop/X-Plane 11", "/vagrant/xplane_11", owner: "vagrant", group: "vagrant", mount_options: ["dmode=775,fmode=775"]
+
+  # 2. Enable the line below and update the path to point your X-Plane 11 path in Windows. This is to allow selecting overlay folder.
+  # config.vm.synced_folder "D:/X-Plane 11", "/vagrant/xplane_11", owner: "vagrant", group: "vagrant", mount_options: ["dmode=775,fmode=775"]
+
+  ###########################################
+
   config.vm.provision "shell", inline: <<-SCRIPT
 echo "Updating ubuntu password"
 echo "ubuntu:ubuntu" | chpasswd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,5 +7,9 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
 
+  config.vm.provider "virtualbox" do |v|
+    v.gui = true
+  end
+
   config.vm.provision :shell, path: "provision_script.sh"
 end

--- a/provision_script.sh
+++ b/provision_script.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+apt-get -y update
+
+# This is just to make sure you have the latest Ubuntu Xenial
+apt-get -y upgrade
+
+apt-get install -y python3 \
+    python3-pip \
+    python3-requests \
+    python3-numpy \
+    python3-pyproj \
+    python3-gdal \
+    python3-shapely \
+    python3-rtree \
+    python3-pil \
+    python3-pil.imagetk \
+    p7zip-full
+
+apt-get -y update

--- a/provision_script.sh
+++ b/provision_script.sh
@@ -15,6 +15,7 @@ apt-get install -y python3 \
     python3-rtree \
     python3-pil \
     python3-pil.imagetk \
-    p7zip-full
+    p7zip-full \
+    ubuntu-desktop
 
 apt-get -y update

--- a/provision_script.sh
+++ b/provision_script.sh
@@ -15,7 +15,9 @@ apt-get install -y python3 \
     python3-rtree \
     python3-pil \
     python3-pil.imagetk \
-    p7zip-full \
-    ubuntu-desktop
+    p7zip-full
+
+# Uncomment the line below only if you have turned on the GUI on the Vagrantfile
+# apt-get install -y ubuntu-desktop
 
 apt-get -y update

--- a/vagrant_installation.txt
+++ b/vagrant_installation.txt
@@ -4,17 +4,15 @@ Ever wish you didn't have to install any dependent libraries, python etc? Fortun
 
 1. One common way to install and run Ortho4XP for Windows, Mac, and Ubuntu. That means core developer can focus more on fixing bugs or work on new features rather than trying to figure out how it can be installed on different OS.
 
-2. Your operating system doesn't get affected by the installation.
+2. Your operating system doesn't get affected by Ortho4XP dependencies.
 
 3. If you want to remove Ortho4XP. Just run vagrant destroy command and remove the Ortho4XP directory. Done. Nothing to remove from the registry or anything.
 
 =============================
-|							|
 |	Vagrant installation 	|
-|							|
 =============================
 
-Using vagrant installation requires following these steps very carefully. The order is very important. Yes, it may be a little long. But trust me, it gets easier after that.
+Vagrant installation requires following these steps very carefully. The order of the steps are very important.
 
 1. Download and install vagrant from here: https://www.vagrantup.com/downloads.html
 
@@ -22,21 +20,21 @@ Using vagrant installation requires following these steps very carefully. The or
 
 3. Download the Ortho4XP zip from the Github repo or clone it on your PC/Mac.
 
-4. Now Open a terminal or Command Prompt window. Windows users: Please make sure you open the command prompt using Administrator.
+4. Now Open a terminal or Command Prompt window. Windows users: Please make sure you open the command prompt as Administrator.
 
-5. In the command prompt or terminal make sure you are inside the downloaded/cloned directory. Ex: C:\Ortho4XP
+5. Navigate to the downloaded/cloned directory using your command prompt (Windows/Mac). Ex: C:\Ortho4XP
 
-6. Now from your command prompt, run the following command: vagrant up
+6. Now run the following command: vagrant up
 
 7. The command above will download an Ubuntu OS and run few scripts to set up everything for you. This could take 15-30 mins depending on your internet connection.
 
-8. Once the setup is complete. Run: vagrant halt
+8. Once the setup is complete, run: vagrant halt
 
 9. Yes, you have to pause the vagrant instance for a reason unknown for now. But don't worry move on to the next step.
 
 10. Now run following command again: vagrant up
 
-11. This time it will be much faster because the download and setup are complete. It's just bringing the VM up.
+11. This time it will be much faster because the download and setup are both complete. It's just bringing the VM up.
 
 12. Once the VM is up, go to VM screen and login as vagrant with the password shown below. The passwords are:
 
@@ -48,7 +46,7 @@ Using vagrant installation requires following these steps very carefully. The or
 13. On the VM window, there should be a Devices menu. Click on Devices -> Insert Guest Additions CD Image... 
 There will be a message saying "Unable to mount VBox_GAs_5.2.16". Just press OK for now. We will fix it.
 
-14. Double click the Fix_VBox icon on the Ubuntu desktop. Type yes when asked to continue.
+14. Double click the Fix_VBox icon on the Ubuntu desktop. Type yes and press enter when asked to continue.
 
 15. Once the step above finishes installing, the window will close itself automatically.
 
@@ -66,9 +64,9 @@ You will only repeat the following steps everytime you want to run Ortho4XP.
 
 3. Now login into Ubuntu using the vagrant account with its password.
 
-4. You can now double-click the Ortho4XP icon to run the application.
+4. Double click the Ortho4XP icon to run the application.
 
-5. Once you are done using Ortho4XP, in your windows/mac command prompt run: vagrant halt
+5. Once you are done using Ortho4XP, run this command in your windows/mac command prompt: vagrant halt
 
-6. The above command turns off the vagrant instance for you. You can now move the tiles and overlays from the directory to your Xplane 10/11 custom scenary directory.
+6. The above command turns off the vagrant instance for you. Feel free to move the tiles and overlays from the directory to your Xplane 10/11 custom scenary directory.
 

--- a/vagrant_installation.txt
+++ b/vagrant_installation.txt
@@ -1,0 +1,73 @@
+Vagrant
+-------
+Ever wish you didn't have to install any dependent libraries, python etc? Fortunately, there is a way that you can completely isolate the installation of Ortho4XP using vagrant. Vagrant allows you to create a Virtual Machine (VM) and install a minimal Ubuntu instance and run Ortho4XP there. This is beneficial for a couple of reasons:
+
+1. One common way to install and run Ortho4XP for Windows, Mac, and Ubuntu. That means core developer can focus more on fixing bugs or work on new features rather than trying to figure out how it can be installed on different OS.
+
+2. Your operating system doesn't get affected by the installation.
+
+3. If you want to remove Ortho4XP. Just run vagrant destroy command and remove the Ortho4XP directory. Done. Nothing to remove from the registry or anything.
+
+=============================
+|							|
+|	Vagrant installation 	|
+|							|
+=============================
+
+Using vagrant installation requires following these steps very carefully. The order is very important. Yes, it may be a little long. But trust me, it gets easier after that.
+
+1. Download and install vagrant from here: https://www.vagrantup.com/downloads.html
+
+2. Download and Virtualbox from here: https://www.virtualbox.org/wiki/Downloads
+
+3. Download the Ortho4XP zip from the Github repo or clone it on your PC/Mac.
+
+4. Now Open a terminal or Command Prompt window. Windows users: Please make sure you open the command prompt using Administrator.
+
+5. In the command prompt or terminal make sure you are inside the downloaded/cloned directory. Ex: C:\Ortho4XP
+
+6. Now from your command prompt, run the following command: vagrant up
+
+7. The command above will download an Ubuntu OS and run few scripts to set up everything for you. This could take 15-30 mins depending on your internet connection.
+
+8. Once the setup is complete. Run: vagrant halt
+
+9. Yes, you have to pause the vagrant instance for a reason unknown for now. But don't worry move on to the next step.
+
+10. Now run following command again: vagrant up
+
+11. This time it will be much faster because the download and setup are complete. It's just bringing the VM up.
+
+12. Once the VM is up, go to VM screen and login as vagrant with the password shown below. The passwords are:
+
+	Account		Password
+	------- 	--------
+	vagrant 	vagrant
+	ubuntu 		ubuntu
+
+13. On the VM window, there should be a Devices menu. Click on Devices -> Insert Guest Additions CD Image... 
+There will be a message saying "Unable to mount VBox_GAs_5.2.16". Just press OK for now. We will fix it.
+
+14. Double click the Fix_VBox icon on the Ubuntu desktop.
+
+15. Once the step above finishes installing, the window will close itself automatically.
+
+16. We are done installing.
+
+17. On your command prompt (i.e Windows/Mac, not the Ubuntu terminal), run this command: vagrant halt
+
+Running the Ortho4XP
+--------------------
+
+1. Once the installation is done, please run: vagrant up
+
+2. Once all the commands are finished, there should be a VM window with the Ubuntu login screen. But before login into Ubuntu, make sure your command prompt (in Windows/Mac) has finished everything and ready to take new commands. Don't log in until it finishes.
+
+3. Now login into Ubuntu using the vagrant account with its password.
+
+4. You can now just double-click the Ortho4XP icon to run the application. That's it.
+
+5. Once you are done using Ortho4XP, just run: vagrant halt
+
+6. The above command turns off the vagrant instance for you. You can now move the tiles and overlays from the directory to your Xplane 10/11 custom scenary directory.
+

--- a/vagrant_installation.txt
+++ b/vagrant_installation.txt
@@ -48,7 +48,7 @@ Using vagrant installation requires following these steps very carefully. The or
 13. On the VM window, there should be a Devices menu. Click on Devices -> Insert Guest Additions CD Image... 
 There will be a message saying "Unable to mount VBox_GAs_5.2.16". Just press OK for now. We will fix it.
 
-14. Double click the Fix_VBox icon on the Ubuntu desktop.
+14. Double click the Fix_VBox icon on the Ubuntu desktop. Type yes when asked to continue.
 
 15. Once the step above finishes installing, the window will close itself automatically.
 
@@ -58,16 +58,17 @@ There will be a message saying "Unable to mount VBox_GAs_5.2.16". Just press OK 
 
 Running the Ortho4XP
 --------------------
+You will only repeat the following steps everytime you want to run Ortho4XP.
 
-1. Once the installation is done, please run: vagrant up
+1. Please open your command prompt/terminal (Windows users: as Administrator) and run: vagrant up
 
-2. Once all the commands are finished, there should be a VM window with the Ubuntu login screen. But before login into Ubuntu, make sure your command prompt (in Windows/Mac) has finished everything and ready to take new commands. Don't log in until it finishes.
+2. Once the vagrant up command finishes, there should be a VM window with the Ubuntu login screen. But before login into Ubuntu, make sure your command prompt (in Windows/Mac) has finished everything and ready to take new commands. Don't log in until it finishes.
 
 3. Now login into Ubuntu using the vagrant account with its password.
 
 4. You can now just double-click the Ortho4XP icon to run the application. That's it.
 
-5. Once you are done using Ortho4XP, just run: vagrant halt
+5. Once you are done using Ortho4XP, in your windows/mac command prompt just run: vagrant halt
 
 6. The above command turns off the vagrant instance for you. You can now move the tiles and overlays from the directory to your Xplane 10/11 custom scenary directory.
 

--- a/vagrant_installation.txt
+++ b/vagrant_installation.txt
@@ -66,9 +66,9 @@ You will only repeat the following steps everytime you want to run Ortho4XP.
 
 3. Now login into Ubuntu using the vagrant account with its password.
 
-4. You can now just double-click the Ortho4XP icon to run the application. That's it.
+4. You can now double-click the Ortho4XP icon to run the application.
 
-5. Once you are done using Ortho4XP, in your windows/mac command prompt just run: vagrant halt
+5. Once you are done using Ortho4XP, in your windows/mac command prompt run: vagrant halt
 
 6. The above command turns off the vagrant instance for you. You can now move the tiles and overlays from the directory to your Xplane 10/11 custom scenary directory.
 

--- a/vagrant_installation.txt
+++ b/vagrant_installation.txt
@@ -24,35 +24,37 @@ Vagrant installation requires following these steps very carefully. The order of
 
 5. Navigate to the downloaded/cloned directory using your command prompt (Windows/Mac). Ex: C:\Ortho4XP
 
-6. Now run the following command: vagrant up
+6. Edit the Vagrantfile and remove # for the OS of your choice to enable synced shared folder. So that you can use it for to select overlay folder / custom scenary. Save it.
 
-7. The command above will download an Ubuntu OS and run few scripts to set up everything for you. This could take 15-30 mins depending on your internet connection.
+7. Now on your command prompt, run the following command: vagrant up
 
-8. Once the setup is complete, run: vagrant halt
+8. The command above will download an Ubuntu OS and run few scripts to set up everything for you. This could take 15-30 mins depending on your internet connection.
 
-9. Yes, you have to pause the vagrant instance for a reason unknown for now. But don't worry move on to the next step.
+9. Once the setup is complete, run: vagrant halt
 
-10. Now run following command again: vagrant up
+10. Yes, you have to pause the vagrant instance for a reason unknown for now. But don't worry move on to the next step.
 
-11. This time it will be much faster because the download and setup are both complete. It's just bringing the VM up.
+11. Now run following command again: vagrant up
 
-12. Once the VM is up, go to VM screen and login as vagrant with the password shown below. The passwords are:
+12. This time it will be much faster because the download and setup are both complete. It's just bringing the VM up.
+
+13. Once the VM is up, go to VM screen and login as vagrant with the password shown below. The passwords are:
 
 	Account		Password
 	------- 	--------
 	vagrant 	vagrant
 	ubuntu 		ubuntu
 
-13. On the VM window, there should be a Devices menu. Click on Devices -> Insert Guest Additions CD Image... 
+14. On the VM window, there should be a Devices menu. Click on Devices -> Insert Guest Additions CD Image... 
 There will be a message saying "Unable to mount VBox_GAs_5.2.16". Just press OK for now. We will fix it.
 
-14. Double click the Fix_VBox icon on the Ubuntu desktop. Type yes and press enter when asked to continue.
+15. Double click the Fix_VBox icon on the Ubuntu desktop. Type yes and press enter when asked to continue.
 
-15. Once the step above finishes installing, the window will close itself automatically.
+16. Once the step above finishes installing, the window will close itself automatically.
 
-16. We are done installing.
+17. We are done installing.
 
-17. On your command prompt (i.e Windows/Mac, not the Ubuntu terminal), run this command: vagrant halt
+18. On your command prompt (i.e Windows/Mac, not the Ubuntu terminal), run this command: vagrant halt
 
 Running the Ortho4XP
 --------------------


### PR DESCRIPTION
## Purpose:
This PR is to enable developers / beta testers to use vagrant box for Ortho4XP project. So they don't have to go through the pain of installing all the packages in different OS. Using vagrant will take care of setting up the environment in an Ubuntu VM. Ex: Any Windows/Mac user will be able to install vagrant and run few commands to get the code up and running without messing up their Windows/Mac environment.

## How to test the PR:
1. Setup Vagrant: [https://www.vagrantup.com/intro/getting-started/install.html](https://www.vagrantup.com/intro/getting-started/install.html)

2. Once VirtualBox/VMWare and Vagrant is running, open your terminal/command prompt. 

3. Git Clone the Ortho4XP project just as usual: 
`git clone https://github.com/oscarpilote/Ortho4XP.git`

4. Now switch to `use_vagrant` branch issuing: 
`git checkout -b use_vagrant origin/use_vagrant`

5. Now run: `vagrant up`

6. Once everything is done, run the following command: `vagrant ssh`. You will be logged into the VM's terminal.

7. Change the directory: `cd /vagrant` (This is the directory Vagrant automatically maps to hosts' current directory)

8. Everything should be installed already, so just issue something like this: 
`python3 Ortho4XP_v130.py +38 -121 Arc 17`

9. The code should run and get the tiles and overlays.

@oscarpilote: Can you please check this one out?
