### PR TITLE
utf-8 encoding while opening extent dir files

### DIFF
--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -80,7 +80,7 @@ def initialize_extents_dict():
             if '.' not in file_name or file_name.split('.')[-1]!='ext': continue
             extent_code=file_name.split('.')[0]
             extent={}
-            f=open(os.path.join(FNAMES.Extent_dir,dir_name,file_name),'r')
+            f=open(os.path.join(FNAMES.Extent_dir,dir_name,file_name),'r',encoding='utf-8')
             valid_extent=True
             for line in f.readlines():
                 line=line[:-1]


### PR DESCRIPTION
This PR fix this error while decoding utf-8 files (names in `Extents/LowRes/France.ext` for example):

```
$ ./Ortho4XP_v130.py 45 -074 Arc 17
Creating missing directory ./Previews
Creating missing directory ./OSM_data
Creating missing directory ./Masks
Creating missing directory ./Orthophotos
Creating missing directory ./Elevation_data
Creating missing directory ./Geotiffs
Creating missing directory ./Patches
Creating missing directory ./Tiles
Creating missing directory ./tmp
Traceback (most recent call last):
  File "./Ortho4XP_v130.py", line 34, in <module>
    IMG.initialize_extents_dict()
  File "./src/O4_Imagery_Utils.py", line 85, in initialize_extents_dict
    for line in f.readlines():
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 92: ordinal not in range(128)
$
```