### PR TITLE
fix true_server_code reference before assignment

### DIFF
--- a/src/O4_OSM_Utils.py
+++ b/src/O4_OSM_Utils.py
@@ -348,6 +348,7 @@ def get_overpass_data(query,bbox,server_code=None):
     tentative=1
     while True:
         s=requests.Session()
+        true_server_code = server_code
         if not server_code:
            true_server_code = random.choice(list(overpass_servers.keys())) if overpass_server_choice=='random' else overpass_server_choice
         base_url=overpass_servers[true_server_code]


### PR DESCRIPTION
When calling  get_overpass_data() with a server_code provided, the function crashes with "UnboundLocalError: local variable 'true_server_code' referenced before assignment"