### PR TITLE
Improve mac install: replace git install of pyproj with PiPy install

### DIFF
--- a/install_mac.sh
+++ b/install_mac.sh
@@ -2,8 +2,7 @@
 brew install python gdal spatialindex p7zip
 
 # Install pyproj
-pip3 install cython
-pip3 install git+https://github.com/jswhit/pyproj.git
+pip3 install pyproj
 
 # Install other dependencies
 pip3 install numpy shapely rtree pillow requests


### PR DESCRIPTION
Replace the direct installation of pyproj from its git repository with an installation from PiPy, as the git installation was a hack to avoid installation errors with the PiPy install, this is no longer necessary.