### PR TITLE
Arch install instruction

### DIFF
--- a/Install_Instructions.txt
+++ b/Install_Instructions.txt
@@ -15,13 +15,22 @@ updates or bugs fixed), the Binary directory won't be necessary anymore.
 
 The following instructions are for the script install :
 
-Linux (Debian derived, names might slightly differ for other distros)
+Linux 
 -----
-
+Debian/Ubuntu-based distributions 
 sudo apt-get install python3 python3-pip python3-requests python3-numpy python3-pyproj python3-gdal python3-shapely python3-rtree python3-pil python3-pil.imagetk p7zip-full libnvtt-bin freeglut3
 
-(if some of them were note packaged for your distro you can use pip instead, like say, pip install pyproj)
+Arch-based distributions
+(You must have the AUR enabled and yay installed)
 
+yay nvidia-texture-tools
+(this will download, build and install the Nvidia Texture Tools package which includes some necessary modules for Ortho4XP)
+
+sudo pacman -S python python-pip python-requests python-numpy python-pyproj python-gdal python-shapely python-rtree python-pillow python-pmw p7zip freeglut
+
+(if some of them were not packaged for your distro you can use pip instead, like say, pip install pyproj)
+
+Python module names may be different on other distributions.
 
 Windows
 -------


### PR DESCRIPTION
Added instructions on how to install on Arch-based Linux distributions. Tested on two machines and works.