### PR TITLE
migrating to pyproj2 syntax for transformers and CRS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Tiles/
 **/Thumbs.db
 **/*.bak
 .last_gui_params.txt
+
+.venv

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,9 +1,5 @@
 # Install dependencies
 brew install python gdal spatialindex p7zip
 
-# Install pyproj
-pip3 install cython
-pip3 install git+https://github.com/jswhit/pyproj.git
-
 # Install other dependencies
-pip3 install numpy shapely rtree pillow requests
+pip3 install numpy pyproj shapely rtree pillow requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.9
+numpy==1.19.0
+Pillow==7.1.2
+pyproj==2.6.1.post1
+requests==2.24.0
+Rtree==0.9.4
+Shapely==1.7.0
+urllib3==1.25.9

--- a/src/O4_Geo_Utils.py
+++ b/src/O4_Geo_Utils.py
@@ -9,16 +9,16 @@ def lon_to_m(lat):
 def m_to_lon(lat):
     return m_to_lat/cos(pi*lat/180) 
 
+epsg={}
+
+
 def dist(A,B):
     # A=(lona,lata), B=(lonb,latb)
     # returns the great circle distance between A and B over the earth surface
     a=sin((A[1]-B[1])*pi/360)**2+cos(A[1]*pi/180)*cos(B[1]*pi/180)*sin((A[0]-B[0])*pi/360)**2
     return 2*earth_radius*atan2(sqrt(a),sqrt(1-a))
 
-epsg={}
-epsg['4326']=pyproj.Proj(init='epsg:4326')
-epsg['3857']=pyproj.Proj(init='epsg:3857')
-    
+
 
 ##############################################################################
 def webmercator_pixel_size(lat,zoomlevel):
@@ -27,7 +27,8 @@ def webmercator_pixel_size(lat,zoomlevel):
 
 ##############################################################################
 def transform(s_epsg, t_epsg, s_x, s_y):
-    return pyproj.transform(epsg[s_epsg], epsg[t_epsg], s_x, s_y)
+    transformer = pyproj.Transformer.from_crs("epsg:" + s_epsg, "epsg:" + t_epsg, always_xy=True)
+    return transformer.transform(s_x, s_y)
 ##############################################################################
 
 ##############################################################################

--- a/src/O4_Geotag.py
+++ b/src/O4_Geotag.py
@@ -1,9 +1,10 @@
 import os
-import pyproj
+from pyproj import Transformer
 from math import pi, exp, atan
 
-geographic=pyproj.Proj(init='epsg:4326')
-webmercator=pyproj.Proj(init='epsg:3857')
+geographic='4326'
+webmercator='3857'
+transformer = Transformer.from_crs("epsg:" +transformer, "epsg:" + webmercator, always_xy=True)
 
 def gtile_to_wgs84(til_x,til_y,zoomlevel):
     rat_x=(til_x/(2**(zoomlevel-1))-1)
@@ -20,7 +21,7 @@ for f in os.listdir():
     zoomlevel=int(items[-1][-6:-4])
     (latmax,lonmin)=gtile_to_wgs84(til_x_left,til_y_top,zoomlevel)
     (latmin,lonmax)=gtile_to_wgs84(til_x_left+16,til_y_top+16,zoomlevel)
-    (xmin,ymin)=pyproj.transform(geographic,webmercator,lonmin,latmin)
-    (xmax,ymax)=pyproj.transform(geographic,webmercator,lonmax,latmax)
+    (xmin,ymin)=transformer.transform(lonmin,latmin)
+    (xmax,ymax)=transformer.transform(lonmax,latmax)
     os.system("gdal_translate -of Gtiff -co COMPRESS=JPEG -a_ullr "+str(xmin)+" "+str(ymax)+" "+str(xmax)+" "+str(ymin)+" -a_srs epsg:3857 "+f+" "+f.replace(".jpg","_tmp.tif"))
     os.system("gdalwarp -of Gtiff -co COMPRESS=JPEG -s_srs epsg:3857 -t_srs epsg:4326 -ts 4096 4096 -rb "+f.replace(".jpg","_tmp.tif")+" "+f.replace(".jpg",".tif"))

--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -195,11 +195,11 @@ def initialize_providers_dict():
                         valid_provider=False
                 elif key=='epsg_code':
                     try:
-                        GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:'+value)
+                        GEO.epsg[value]=value
                     except:
                         # HACK for Slovenia 
                         if int(value)==102060:
-                            GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:3912')
+                            GEO.epsg[value]='epsg:3912'
                         else:
                             UI.vprint(0,"Error in epsg code for provider",provider_code)
                             valid_provider=False

--- a/src/O4_Mask_Utils.py
+++ b/src/O4_Mask_Utils.py
@@ -511,11 +511,10 @@ if __name__ == '__main__':
     if epsg_code!='4326':
         name+='_'+epsg_code
         print("Changing coordinates to match EPSG code")
-        import pyproj
+        from pyproj import Transformer
         import shapely.ops
-        s_proj=pyproj.Proj(init='epsg:4326')
-        t_proj=pyproj.Proj(init='epsg:'+epsg_code)
-        reprojection = lambda x, y: pyproj.transform(s_proj, t_proj, x, y)
+        transformer = Transformer.from_crs("epsg:4326", "epsg:"+ epsg_code, always_xy=True)
+        reprojection = lambda x, y: transformer.transform(x, y)
         multipolygon_area=shapely.ops.transform(reprojection,multipolygon_area)
 
     vector_map.encode_MultiPolygon(multipolygon_area,VECT.dummy_alt,'WATER',check=True,cut=False)


### PR DESCRIPTION
PROJ changed the axis order.  [see background](https://proj.org/faq.html#why-is-the-axis-ordering-in-proj-not-consistent) and https://github.com/pyproj4/pyproj/issues/224#issuecomment-476647824

This PR migrates all +init=syntax, removes references to Proj class, and we are addressing the deprecation warnings and #126

`FutureWarning: '+init=<authority>:<code>' syntax is deprecated. '<authority>:<code>' is the preferred initialization method.`

PyProj recommended migration path
[PyProj2 Gotchas FAQ](https://pyproj4.github.io/pyproj/stable/gotchas.html#init-auth-auth-code-should-be-replaced-with-auth-auth-code)
