### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+certifi==2021.5.30
+chardet==4.0.0
+idna==2.10
+numpy==1.21.0
+Pillow==8.2.0
+pyproj==3.1.0
+requests==2.25.1
+Rtree==0.9.7
+Shapely==1.7.1
+urllib3==1.26.6


### PR DESCRIPTION
Added a "requirements.txt" file for easyier "pip install installation" .
To install all required pyton modules just run "pip install -r requirements.txt"