### PR TITLE
Add gdal-bin to Debian/Ubuntu dependencies

### DIFF
--- a/Install_Instructions.txt
+++ b/Install_Instructions.txt
@@ -18,7 +18,7 @@ The following instructions are for the script install :
 Linux 
 -----
 Debian/Ubuntu-based distributions 
-sudo apt-get install python3 python3-pip python3-requests python3-numpy python3-pyproj python3-gdal python3-shapely python3-rtree python3-pil python3-pil.imagetk p7zip-full libnvtt-bin freeglut3
+sudo apt-get install python3 python3-pip python3-requests python3-numpy python3-pyproj python3-gdal python3-shapely python3-rtree python3-pil python3-pil.imagetk p7zip-full libnvtt-bin freeglut3 gdal-bin
 
 Arch-based distributions
 (You must have the AUR enabled and yay installed)


### PR DESCRIPTION
I got the error: `FileNotFoundError: [Errno 2] No such file or directory: 'gdal_translate'` when trying to run the `Make GeoTiffs` feature until I installed the `gdal-bin` package.