### PR TITLE
Fixing deprecations for Shapely 2.0, Numpy and Pyproj

### DIFF
--- a/Providers/Netherland/PDOK.lay
+++ b/Providers/Netherland/PDOK.lay
@@ -1,0 +1,10 @@
+request_type=wmts
+epsg_code=3857
+layers=Actueel_ortho25
+tilematrixset=EPSG:3857
+tile_size=256
+url_prefix=https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0?
+in_GUI=True
+imagery_dir=grouped
+extent=Netherlands
+#color_filters=PDOK20

--- a/src/O4_Airport_Utils.py
+++ b/src/O4_Airport_Utils.py
@@ -500,7 +500,7 @@ def encode_runways_taxiways_and_aprons(tile,airport_layer,dico_airports,vector_m
             for k in range(1,len(way)):
                 try:
                     lin=geometry.LineString([way_r[k],way_l[k]]).intersection(runway_pol)
-                    if lin.geom_type=="LineString":
+                    if lin.geom_type == "LineString" and not lin.is_empty:
                         trav=numpy.round(numpy.array(lin),7)
                         alti_trav=numpy.array([VECT.weighted_alt(node,alt_idx,alt_dico,tile.dem) for node in trav]).reshape((len(trav),1))
                         vector_map.insert_way(numpy.hstack([trav,alti_trav]),'DUMMY',check=True)
@@ -518,16 +518,18 @@ def encode_runways_taxiways_and_aprons(tile,airport_layer,dico_airports,vector_m
                 abscissae=[boundary.project(geometry.Point(x)) for x in boundary.coords]
                 traverses=[]
                 for k in range(1,len(way)):
-                    try:
-                        lin=geometry.LineString([way_r[k],way_l[k]]).intersection(runway_pol)
-                        if lin.geom_type=="LineString":
-                            abs1=boundary.project(geometry.Point(lin.coords[0]))
-                            abs2=boundary.project(geometry.Point(lin.coords[-1]))
-                            traverses.append((abs1,abs2))
-                            abscissae+=[abs1,abs2]
-                    except Exception as e:
-                        print(e)
-                        pass
+                    lin = geometry.LineString([way_r[k], way_l[k]]).intersection(
+                        runway_pol
+                    )
+                  
+                    if lin.geom_type == "LineString" and not lin.is_empty:
+                        p1 = lin.coords[0]
+                        p2 = lin.coords[1]
+                        abs1 = boundary.project(geometry.Point(p1))
+                        abs2 = boundary.project(geometry.Point(p2))
+                        traverses.append((abs1, abs2))
+                        abscissae += [abs1, abs2]
+                  
                 abscissae=sorted(set(abscissae))
                 way=numpy.round(numpy.array([boundary.interpolate(x).coords[0] for x in abscissae+[0]]),7)
                 alti_way=numpy.array([VECT.weighted_alt(node,alt_idx,alt_dico,tile.dem) for node in way]).reshape((len(way),1))

--- a/src/O4_Airport_Utils.py
+++ b/src/O4_Airport_Utils.py
@@ -64,7 +64,7 @@ def discover_airport_names(airport_layer,dico_airports):
                     pass
             try:
                 dico_airports[key]['boundary']=geometry.Polygon(numpy.array([airport_layer.dicosmn[nodeid] for nodeid in airport_layer.dicosmw[osmid]])) if osmtype=='w'\
-                                           else ops.cascaded_union([geom for geom in [geometry.Polygon(numpy.array([airport_layer.dicosmn[nodeid] for nodeid in nodelist])) for nodelist in airport_layer.dicosmr[osmid]['outer']]]) if osmtype=='r'\
+                                           else ops.unary_union([geom for geom in [geometry.Polygon(numpy.array([airport_layer.dicosmn[nodeid] for nodeid in nodelist])) for nodelist in airport_layer.dicosmr[osmid]['outer']]]) if osmtype=='r'\
                                            else None
                 if dico_airports[key]['boundary'] and not dico_airports[key]['boundary'].is_valid: 
                     UI.lvprint(2,"Airport ",dico_airports[key],"OSM boundary is an invalid polygon, boundary set to None.")
@@ -265,7 +265,7 @@ def sort_and_reconstruct_runways(tile,airport_layer,dico_airports):
                 i+=1
             if keep_this: runways_as_line.append((pol, runway_start,runway_end,width))
         ##  Save (overwrite) this into the dico_airport runway dictionnary
-        runway_area=VECT.ensure_MultiPolygon(ops.cascaded_union([item[0] for item in runways_as_area+runways_as_line]))
+        runway_area=VECT.ensure_MultiPolygon(ops.unary_union([item[0] for item in runways_as_area+runways_as_line]))
         dico_airports[airport]['runway']=(runway_area,runways_as_area,runways_as_line)   
     return
 ####################################################################################################
@@ -300,7 +300,7 @@ def build_hangar_areas(tile,airport_layer,dico_airports):
                 UI.vprint(2,"Unable to turn hangar area to polygon, close to",airport_layer.dicosmn[airport_layer.dicosmw[wayid][0]]) 
                 continue
             hangars.append(pol)
-        hangars=VECT.ensure_MultiPolygon(VECT.improved_buffer(ops.cascaded_union(hangars),2,1,0.5))
+        hangars=VECT.ensure_MultiPolygon(VECT.improved_buffer(ops.unary_union(hangars),2,1,0.5))
         dico_airports[airport]['hangar']=hangars
 ####################################################################################################    
 
@@ -319,7 +319,7 @@ def build_apron_areas(tile,airport_layer,dico_airports):
                 UI.vprint(2,"Unable to turn apron area to polygon, close to",airport_layer.dicosmn[airport_layer.dicosmw[wayid][0]]) 
                 continue
             aprons.append(pol)
-        aprons=VECT.ensure_MultiPolygon(ops.cascaded_union(aprons))
+        aprons=VECT.ensure_MultiPolygon(ops.unary_union(aprons))
         dico_airports[airport]['apron']=(aprons,dico_airports[airport]['apron'])
     return
 ####################################################################################################    
@@ -338,9 +338,9 @@ def build_taxiway_areas(tile,airport_layer,dico_airports):
 def update_airport_boundaries(tile,dico_airports):
     for airport in dico_airports:
         apt=dico_airports[airport]
-        boundary=ops.cascaded_union([apt['taxiway'][0],apt['apron'][0],apt['hangar'],apt['runway'][0]])
+        boundary=ops.unary_union([apt['taxiway'][0],apt['apron'][0],apt['hangar'],apt['runway'][0]])
         if apt['boundary']:
-            apt['boundary']=VECT.ensure_MultiPolygon(ops.cascaded_union([affinity.translate(apt['boundary'],-tile.lon,-tile.lat),boundary]).buffer(0).simplify(0.00001))
+            apt['boundary']=VECT.ensure_MultiPolygon(ops.unary_union([affinity.translate(apt['boundary'],-tile.lon,-tile.lat),boundary]).buffer(0).simplify(0.00001))
         else:
             apt['boundary']=VECT.ensure_MultiPolygon(boundary.buffer(0).simplify(0.00001))
     # pickle dico_airports for later use in Step 2 (apt_curv_tol) and Step 3 (cover_airports_with_high_res)
@@ -425,8 +425,8 @@ def smooth_raster_over_airports(tile,dico_airports,preserve_boundary=True):
         Y1=y1-rowmin*ystep
         airport_im=Image.new('L',(upscale*(colmax-colmin+1),upscale*(rowmax-rowmin+1)))
         airport_draw=ImageDraw.Draw(airport_im)
-        full_area=VECT.ensure_MultiPolygon(ops.cascaded_union([dico_airports[airport]['boundary'],dico_airports[airport]['runway'][0],dico_airports[airport]['hangar'],dico_airports[airport]['taxiway'][0],dico_airports[airport]['apron'][0]]))
-        for polygon in full_area:
+        full_area=VECT.ensure_MultiPolygon(ops.unary_union([dico_airports[airport]['boundary'],dico_airports[airport]['runway'][0],dico_airports[airport]['hangar'],dico_airports[airport]['taxiway'][0],dico_airports[airport]['apron'][0]]))
+        for polygon in full_area.geoms:
             exterior_pol_pix=[(round(upscale*(X-X0)/xstep),round(upscale*(Y1-Y)/ystep)) for (X,Y) in polygon.exterior.coords]
             airport_draw.polygon(exterior_pol_pix,fill='white')
             for inner_ring in polygon.interiors:
@@ -538,10 +538,16 @@ def encode_runways_taxiways_and_aprons(tile,airport_layer,dico_airports,vector_m
                     vector_map.insert_way(numpy.hstack([trav,alti_trav]),'DUMMY',check=True)
                 pols.append(pol)
         for pol in pols:
-            for subpol in VECT.ensure_MultiPolygon(pol.difference(ops.cascaded_union([pol2 for pol2 in pols if pol2!=pol]))):
-                seeds['RUNWAY'].append(numpy.array(subpol.representative_point()))
-            for subpol in VECT.ensure_MultiPolygon(pol.intersection(ops.cascaded_union([pol2 for pol2 in pols if pol2!=pol]))):
-                seeds['RUNWAY'].append(numpy.array(subpol.representative_point()))   
+            for subpol in VECT.ensure_MultiPolygon(
+                pol.difference(ops.unary_union([pol2 for pol2 in pols if pol2 != pol]))
+            ).geoms:
+                seeds["RUNWAY"].append(subpol.representative_point().coords)
+            for subpol in VECT.ensure_MultiPolygon(
+                pol.intersection(
+                    ops.unary_union([pol2 for pol2 in pols if pol2 != pol])
+                )
+            ).geoms:
+                seeds["RUNWAY"].append(subpol.representative_point().coords)
         ## Then taxiways
         ## Not sure if it is best to separate them from the runway or not...  
         cleaned_taxiway_area=VECT.improved_buffer(apt['taxiway'][0].difference(VECT.improved_buffer(apt['runway'][0],5,0,0).union(VECT.improved_buffer(apt['hangar'],20,0,0))),3,2,0.5)
@@ -581,7 +587,7 @@ def encode_runways_taxiways_and_aprons(tile,airport_layer,dico_airports,vector_m
     plural_rwy='s' if total_rwy>1 else ''
     plural_taxi='s' if total_taxi>1 else ''    
     UI.vprint(1,"   Auto-patched",total_rwy,"runway"+plural_rwy+" and",total_taxi,"piece"+plural_taxi+" of taxiway.")
-    return ops.cascaded_union([dico_airports[airport]['runway'][0] for airport in dico_airports]+\
+    return ops.unary_union([dico_airports[airport]['runway'][0] for airport in dico_airports]+\
                               [dico_airports[airport]['taxiway'][0] for airport in dico_airports]+\
                               [dico_airports[airport]['apron'][0] for airport in dico_airports])       
 ####################################################################################################        
@@ -622,7 +628,7 @@ def flatten_helipads(airport_layer,vector_map,tile, treated_area):
         #vector_map.insert_way(numpy.hstack([way,alti_way]),'INTERP_ALT',check=True) 
         #seeds.append(numpy.array(pol.representative_point()))
         total+=1
-    helipad_area=ops.cascaded_union(multipol)
+    helipad_area=ops.unary_union(multipol)
     # helipads that are only encoded as nodes, they will be grown into hexagons
     for nodeid in (x for x in airport_layer.dicosmn if x in airport_layer.dicosmtags['n'] and 'aeroway' in airport_layer.dicosmtags['n'][x] and airport_layer.dicosmtags['n'][x]['aeroway']=='helipad'):
         center=numpy.round(numpy.array(airport_layer.dicosmn[nodeid])-numpy.array([tile.lon,tile.lat]),7)
@@ -635,7 +641,7 @@ def flatten_helipads(airport_layer,vector_map,tile, treated_area):
         #vector_map.insert_way(numpy.hstack([way,alti_way]),'INTERP_ALT',check=True) 
         #seeds.append(center)
         total+=1
-    helipad_area=VECT.ensure_MultiPolygon(VECT.cut_to_tile(ops.cascaded_union(multipol)))
+    helipad_area=VECT.ensure_MultiPolygon(VECT.cut_to_tile(ops.unary_union(multipol))).geoms
     for pol in helipad_area:
         if (pol.is_empty) or (not pol.is_valid) or (not pol.area):
             continue

--- a/src/O4_Airport_Utils.py
+++ b/src/O4_Airport_Utils.py
@@ -372,7 +372,7 @@ def list_airports_and_runways(dico_airports):
 
 ####################################################################################################
 def build_airport_array(tile,dico_airports):
-    airport_array=numpy.zeros((1001,1001),dtype=numpy.bool)
+    airport_array=numpy.zeros((1001,1001),dtype=bool)
     for airport in dico_airports:
         (xmin,ymin,xmax,ymax)=dico_airports[airport]['boundary'].bounds
         x_shift=1500*GEO.m_to_lon(tile.lat) 

--- a/src/O4_DEM_Utils.py
+++ b/src/O4_DEM_Utils.py
@@ -546,7 +546,7 @@ def smoothen(raster,pix_width,mask_im,preserve_boundary=True):
     if not pix_width: return raster
     if not mask_im: return raster
     tmp = numpy.array(raster)
-    mask_array = numpy.array(mask_im,dtype=numpy.float)/255
+    mask_array = numpy.array(mask_im,dtype=float)/255
     kernel=numpy.array(range(1,2*(pix_width+1)))
     kernel[pix_width+1:]=range(pix_width,0,-1)
     kernel=kernel/(pix_width+1)**2

--- a/src/O4_DSF_Utils.py
+++ b/src/O4_DSF_Utils.py
@@ -100,7 +100,7 @@ def zone_list_to_ortho_dico(tile):
         # where higher lines have priority over lower ones.
         masks_im=Image.new("L",(4096,4096),'black')
         masks_draw=ImageDraw.Draw(masks_im)
-        airport_array=numpy.zeros((4096,4096),dtype=numpy.bool)
+        airport_array=numpy.zeros((4096,4096),dtype=bool)
         if tile.cover_airports_with_highres in ['True','ICAO']:
             UI.vprint(1,"-> Checking airport locations for upgraded zoomlevel.")
             try:

--- a/src/O4_File_Names.py
+++ b/src/O4_File_Names.py
@@ -6,20 +6,23 @@ g2xpl_16_prefix=''
 g2xpl_16_suffix=''
 
 Ortho4XP_dir  =  '..' if getattr(sys,'frozen',False) else '.'
-Preview_dir   =  os.path.join(Ortho4XP_dir, 'Previews')
-Provider_dir  =  os.path.join(Ortho4XP_dir, 'Providers')
-Extent_dir    =  os.path.join(Ortho4XP_dir, 'Extents')
-Filter_dir    =  os.path.join(Ortho4XP_dir, 'Filters')
-OSM_dir       =  os.path.join(Ortho4XP_dir, 'OSM_data')
-Mask_dir      =  os.path.join(Ortho4XP_dir, 'Masks')
-Imagery_dir   =  os.path.join(Ortho4XP_dir, 'Orthophotos')
-Elevation_dir =  os.path.join(Ortho4XP_dir, 'Elevation_data')
-Geotiff_dir   =  os.path.join(Ortho4XP_dir, 'Geotiffs')
-Patch_dir     =  os.path.join(Ortho4XP_dir, 'Patches')
-Utils_dir     =  os.path.join(Ortho4XP_dir, 'Utils')
-Tile_dir      =  os.path.join(Ortho4XP_dir, 'Tiles')
-Tmp_dir       =  os.path.join(Ortho4XP_dir, 'tmp')
-Overlay_dir  =   os.path.join(Ortho4XP_dir, 'yOrtho4XP_Overlays')
+
+build_dir = "build/"
+
+Preview_dir = os.path.join(Ortho4XP_dir, "Previews")
+Provider_dir = os.path.join(Ortho4XP_dir, "Providers")
+Extent_dir = os.path.join(Ortho4XP_dir, "Extents")
+Filter_dir = os.path.join(Ortho4XP_dir, "Filters")
+OSM_dir = os.path.join(Ortho4XP_dir, build_dir, "OSM_data")
+Mask_dir = os.path.join(Ortho4XP_dir, build_dir, "Masks")
+Imagery_dir = os.path.join(Ortho4XP_dir, build_dir, "Orthophotos")
+Elevation_dir = os.path.join(Ortho4XP_dir, build_dir, "Elevation_data")
+Geotiff_dir = os.path.join(Ortho4XP_dir, build_dir, "Geotiffs")
+Patch_dir = os.path.join(Ortho4XP_dir, "Patches")
+Utils_dir = os.path.join(Ortho4XP_dir, "Utils")
+Tile_dir = os.path.join(Ortho4XP_dir, build_dir, "Tiles")
+Tmp_dir = os.path.join(Ortho4XP_dir, build_dir, "tmp")
+Overlay_dir = os.path.join(Ortho4XP_dir, "yOrtho4XP_Overlays")
 ##############################################################################
 def short_latlon(lat,lon):
     strlat='{:+.0f}'.format(lat).zfill(3)

--- a/src/O4_Geo_Utils.py
+++ b/src/O4_Geo_Utils.py
@@ -1,9 +1,10 @@
 from math import log, tan, pi, atan, exp, cos, sin, sqrt, atan2
-from pyproj import Transformer, Proj
+from pyproj import Transformer
 
 earth_radius = 6378137
 lat_to_m      = pi*earth_radius/180
 m_to_lat      = 1/lat_to_m
+
 def lon_to_m(lat):
     return lat_to_m*cos(pi*lat/180)
 def m_to_lon(lat):
@@ -15,9 +16,6 @@ def dist(A,B):
     a=sin((A[1]-B[1])*pi/360)**2+cos(A[1]*pi/180)*cos(B[1]*pi/180)*sin((A[0]-B[0])*pi/360)**2
     return 2*earth_radius*atan2(sqrt(a),sqrt(1-a))
 
-epsg={}
-epsg['4326']=Proj("epsg:4326")
-epsg['3857']=Proj("epsg:3857")
 ##############################################################################
 def webmercator_pixel_size(lat,zoomlevel):
     return 2*pi*earth_radius*cos(pi*lat/180)/(2**(zoomlevel+8))
@@ -25,7 +23,8 @@ def webmercator_pixel_size(lat,zoomlevel):
 
 ##############################################################################
 def transform(s_epsg, t_epsg, s_x, s_y):
-    return pyproj.transform(epsg[s_epsg], epsg[t_epsg], s_x, s_y)
+    return Transformer.from_crs(crs_from=f"EPSG:{s_epsg}", crs_to=f"EPSG:{t_epsg}").transform(s_x, s_y)
+
 ##############################################################################
 
 ##############################################################################

--- a/src/O4_Geo_Utils.py
+++ b/src/O4_Geo_Utils.py
@@ -1,5 +1,5 @@
 from math import log, tan, pi, atan, exp, cos, sin, sqrt, atan2
-import pyproj
+from pyproj import Transformer, Proj
 
 earth_radius = 6378137
 lat_to_m      = pi*earth_radius/180
@@ -16,10 +16,8 @@ def dist(A,B):
     return 2*earth_radius*atan2(sqrt(a),sqrt(1-a))
 
 epsg={}
-epsg['4326']=pyproj.Proj(init='epsg:4326')
-epsg['3857']=pyproj.Proj(init='epsg:3857')
-    
-
+epsg['4326']=Proj("epsg:4326")
+epsg['3857']=Proj("epsg:3857")
 ##############################################################################
 def webmercator_pixel_size(lat,zoomlevel):
     return 2*pi*earth_radius*cos(pi*lat/180)/(2**(zoomlevel+8))

--- a/src/O4_Geotag.py
+++ b/src/O4_Geotag.py
@@ -2,8 +2,8 @@ import os
 import pyproj
 from math import pi, exp, atan
 
-geographic=pyproj.Proj(init='epsg:4326')
-webmercator=pyproj.Proj(init='epsg:3857')
+geographic=pyproj.Proj('epsg:4326')
+webmercator=pyproj.Proj('epsg:3857')
 
 def gtile_to_wgs84(til_x,til_y,zoomlevel):
     rat_x=(til_x/(2**(zoomlevel-1))-1)

--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -921,7 +921,7 @@ def download_jpeg_ortho(file_dir,file_name,til_x_left,til_y_top,zoomlevel,provid
             super_resol_factor=2**(max_zl-zoomlevel)
     width=height=int(4096*super_resol_factor)
     # we treat first the case of webmercator grid type servers
-    if 'grid_type' in provider and provider['grid_type']=='webmercator':
+    if 'grid_type' in provider and provider['grid_type']=='webmercator' or provider["epsg_code"] == "3857":
         tilbox=[til_x_left,til_y_top,til_x_left+16,til_y_top+16] 
         tilbox_mod=[int(round(p*super_resol_factor)) for p in tilbox]
         zoom_shift=round(log(super_resol_factor)/log(2))

--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -96,17 +96,8 @@ def initialize_extents_dict():
                     print("Error for extent",extent_code,"in line",line)
                     continue
                 # structuring data
-                if key=='epsg_code':
-                    try:
-                        GEO.epsg[value] = pyproj.Proj(f"epsg:{value}")
-                    except:
-                        # HACK for Slovenia
-                        if int(value)==102060:
-                            GEO.epsg[value]= pyproj.Proj("epsg:3912")
-                        else:
-                            print("Error in epsg code for extent",extent_code)
-                            valid_extent=False
-                elif key=='mask_bounds':
+
+                if key=='mask_bounds':
                     try:
                         extent[key]=[float(x) for x in value.split(",")]
                     except:
@@ -195,16 +186,7 @@ def initialize_providers_dict():
                     except:
                         print("Definition of fake headers for provider",provider_code,"not valid.")
                         valid_provider=False
-                elif key=='epsg_code':
-                    try:
-                        GEO.epsg[value]=pyproj.Proj('epsg:'+value)
-                    except:
-                        # HACK for Slovenia 
-                        if int(value)==102060:
-                            GEO.epsg[value]=pyproj.Proj('epsg:3912')
-                        else:
-                            UI.vprint(0,"Error in epsg code for provider",provider_code)
-                            valid_provider=False
+
                 elif key=='in_GUI':
                     try:
                         provider['in_GUI']=eval(value)

--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -3,6 +3,7 @@ import os
 import sys
 import subprocess
 import io
+import pyproj
 import requests
 import queue
 import random
@@ -96,11 +97,11 @@ def initialize_extents_dict():
                 # structuring data
                 if key=='epsg_code':
                     try:
-                        GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:'+value)
+                        GEO.epsg[value] = pyproj.Proj(f"epsg:{value}")
                     except:
-                        # HACK for Slovenia 
+                        # HACK for Slovenia
                         if int(value)==102060:
-                            GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:3912')
+                            GEO.epsg[value]= pyproj.Proj("epsg:3912")
                         else:
                             print("Error in epsg code for extent",extent_code)
                             valid_extent=False
@@ -195,11 +196,11 @@ def initialize_providers_dict():
                         valid_provider=False
                 elif key=='epsg_code':
                     try:
-                        GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:'+value)
+                        GEO.epsg[value]=pyproj.Proj('epsg:'+value)
                     except:
                         # HACK for Slovenia 
                         if int(value)==102060:
-                            GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:3912')
+                            GEO.epsg[value]=pyproj.Proj('epsg:3912')
                         else:
                             UI.vprint(0,"Error in epsg code for provider",provider_code)
                             valid_provider=False

--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -906,7 +906,15 @@ def build_texture_from_bbox_and_size(t_bbox,t_epsg,t_size,provider):
         UI.vprint(3,"Crop needed")
         big_image=big_image.crop((crop_x0,crop_y0,crop_x1,crop_y1))
     if big_image.size!=t_size:
-        UI.vprint(3,"Resize needed:"+str(t_size[0]/big_image.size[0])+" "+str(t_size[1]/big_image.size[1]))
+        try:
+            UI.vprint(3,"Resize needed:"+str(t_size[0]/big_image.size[0])+" "+str(t_size[1]/big_image.size[1]))
+        except ZeroDivisionError as e:
+            # Something is going wrong here. Non-epsg-3857 may be impacted but apart from the print not working
+            # the following resize doesn't actually throw an error.
+            print("division by zero at build_texture_from_bbox_and_size")
+            pass
+        else:
+            print("works")
         big_image=big_image.resize(t_size,Image.BICUBIC)
     return (success,big_image)
 ###############################################################################################################################

--- a/src/O4_Mask_Utils.py
+++ b/src/O4_Mask_Utils.py
@@ -513,8 +513,8 @@ if __name__ == '__main__':
         print("Changing coordinates to match EPSG code")
         import pyproj
         import shapely.ops
-        s_proj=pyproj.Proj(init='epsg:4326')
-        t_proj=pyproj.Proj(init='epsg:'+epsg_code)
+        s_proj=pyproj.Proj('epsg:4326')
+        t_proj=pyproj.Proj(f"epsg:{epsg_code}")
         reprojection = lambda x, y: pyproj.transform(s_proj, t_proj, x, y)
         multipolygon_area=shapely.ops.transform(reprojection,multipolygon_area)
 

--- a/src/O4_OSM_Utils.py
+++ b/src/O4_OSM_Utils.py
@@ -452,11 +452,11 @@ def OSM_to_MultiPolygon(osm_layer,lat,lon,filter=None):
             multiout=[geometry.Polygon(numpy.round(numpy.array([osm_layer.dicosmn[nodeid] \
                                         for nodeid in nodelist],dtype=numpy.float64)-numpy.array([lon,lat],dtype=numpy.float64),7))\
                                         for nodelist in osm_layer.dicosmr[relid]['outer']]
-            multiout=ops.cascaded_union([geom for geom in multiout if geom.is_valid])
+            multiout=ops.unary_union([geom for geom in multiout if geom.is_valid])
             multiin=[geometry.Polygon(numpy.round(numpy.array([osm_layer.dicosmn[nodeid]\
                                         for nodeid in nodelist],dtype=numpy.float64)-numpy.array([lon,lat],dtype=numpy.float64),7))\
                                         for nodelist in osm_layer.dicosmr[relid]['inner']]
-            multiin=ops.cascaded_union([geom for geom in multiin if geom.is_valid])
+            multiin=ops.unary_union([geom for geom in multiin if geom.is_valid])
         except Exception as e:
             UI.logprint(e)
             done+=1

--- a/src/O4_Vector_Map.py
+++ b/src/O4_Vector_Map.py
@@ -251,7 +251,7 @@ def include_sea(vector_map,tile):
         if not remainder.is_empty: 
             remainder=VECT.ensure_MultiLineString(ops.linemerge(remainder))
         UI.vprint(3,"...done.")
-        coastline=geometry.MultiLineString([line for line in remainder]+[line for line in loops])
+        coastline=geometry.MultiLineString([line for line in remainder.geoms]+[line for line in loops.geoms])
         sea_area=VECT.ensure_MultiPolygon(VECT.coastline_to_MultiPolygon(coastline,tile.lat,tile.lon,custom_source)) 
         if sea_area.geoms: UI.vprint(1,"      Found ",len(sea_area.geoms),"contiguous patch(es).")
         for polygon in sea_area.geoms:
@@ -459,7 +459,7 @@ def include_patches(vector_map,tile):
                     if pol.is_valid and pol.area:
                         patches_area=patches_area.union(pol)
                         vector_map.insert_way(numpy.hstack([way,alti_way]),'INTERP_ALT',check=True)
-                        seed=numpy.array(pol.representative_point())
+                        seed=numpy.array(pol.representative_point().coords)
                         if 'INTERP_ALT' in vector_map.seeds:
                             vector_map.seeds['INTERP_ALT'].append(seed)
                         else:

--- a/src/O4_Vector_Map.py
+++ b/src/O4_Vector_Map.py
@@ -255,7 +255,7 @@ def include_sea(vector_map,tile):
         sea_area=VECT.ensure_MultiPolygon(VECT.coastline_to_MultiPolygon(coastline,tile.lat,tile.lon,custom_source)) 
         if sea_area.geoms: UI.vprint(1,"      Found ",len(sea_area.geoms),"contiguous patch(es).")
         for polygon in sea_area.geoms:
-            seed=numpy.array(polygon.representative_point()) 
+            seed=numpy.array(polygon.representative_point().coords)
             if 'SEA' in vector_map.seeds:
                 vector_map.seeds['SEA'].append(seed)
             else:
@@ -382,7 +382,7 @@ def include_patches(vector_map,tile):
         #HACK
         waylist=tuple(df['w'].intersection(dt['w']))+tuple(df['w'].difference(dt['w']))
         for wayid in waylist:
-            way=numpy.array([dn[nodeid] for nodeid in dw[wayid]],dtype=numpy.float)
+            way=numpy.array([dn[nodeid] for nodeid in dw[wayid]],dtype=float)
             way=way-numpy.array([[tile.lon,tile.lat]]) 
             alti_way_orig=tile.dem.alt_vec(way)
             cplx_way=False

--- a/src/O4_Vector_Map.py
+++ b/src/O4_Vector_Map.py
@@ -138,7 +138,7 @@ def include_airports(vector_map,tile):
     APT.smooth_raster_over_airports(tile,dico_airports)
     (patches_area,patches_list)=include_patches(vector_map,tile)
     runway_taxiway_apron_area=APT.encode_runways_taxiways_and_aprons(tile,airport_layer,dico_airports,vector_map,patches_list)
-    treated_area=ops.cascaded_union([patches_area,runway_taxiway_apron_area])
+    treated_area=ops.unary_union([patches_area,runway_taxiway_apron_area])
     APT.encode_hangars(tile,dico_airports,vector_map,patches_list)
     APT.flatten_helipads(airport_layer,vector_map,tile,treated_area)
     #APT.encode_aprons(tile,dico_airports,vector_map)
@@ -546,7 +546,7 @@ def keep_obj8(lat_anchor,lon_anchor,alt_anchor,heading_anchor,objfile_name,vecto
                     else:
                         vector_map.seeds['INTERP_ALT']=[seed]    
                     polist.append(geometry.Polygon([vector_map.nodes_dico[a],vector_map.nodes_dico[b],vector_map.nodes_dico[c],vector_map.nodes_dico[a]]))
-                multipol=VECT.ensure_MultiPolygon(ops.cascaded_union(polist))    
+                multipol=VECT.ensure_MultiPolygon(ops.unary_union(polist))    
             except:
                 pass
     f.close()

--- a/src/O4_Vector_Utils.py
+++ b/src/O4_Vector_Utils.py
@@ -612,8 +612,8 @@ def coastline_to_MultiPolygon(coastline,lat,lon,custom_source=False):
                return geometry.MultiPolygon()
     if not bdpolys: # and islands: 
         bdpolys.append([(0,0),(0,1),(1,1),(1,0)])
-    outpol=ops.cascaded_union([geometry.Polygon(bdpoly).buffer(0) for bdpoly in bdpolys])
-    inpol=ensure_MultiPolygon(cut_to_tile(ops.cascaded_union([geometry.Polygon(loop).buffer(0) for loop in islands+interior_seas]))) 
+    outpol=ops.unary_union([geometry.Polygon(bdpoly).buffer(0) for bdpoly in bdpolys])
+    inpol=ensure_MultiPolygon(cut_to_tile(ops.unary_union([geometry.Polygon(loop).buffer(0) for loop in islands+interior_seas]))) 
     return ensure_MultiPolygon(outpol.symmetric_difference(inpol))
 ##############################################################################
 ##############################################################################


### PR DESCRIPTION
I have been adding some fixes to support Shapely 2.0 and fix some future deprecations around pyproj and numpy.

There is still some weird stuff going on, particularly with providers that don't use 3857. I've mostly been testing with PDOK (Netherlands) as a provider, which does use 3857, but used the non-standard routine anyway. I fixed that, but need to do more testing with non-standard providers.

It takes some time to figure out if these are regressions or not.