### PR TITLE
Hotfixes-130/o4-vector-map/multiple-osm-patches

### DIFF
--- a/src/O4_Vector_Map.py
+++ b/src/O4_Vector_Map.py
@@ -376,7 +376,6 @@ def include_patches(vector_map,tile):
             UI.vprint(1,"     Error in treating",pfile_name,", skipped.")
         patches_list.append(pfile_name[:-10])
         dw=patch_layer.dicosmw; dn=patch_layer.dicosmn; df=patch_layer.dicosmfirst; dt=patch_layer.dicosmtags
-        patches_area=geometry.Polygon()
         # reorganize them so that untagged dummy ways are treated last (due to altitude being first done kept for all)
         #waylist=list(set(dw).intersection(df['w']).intersection(dt['w']))+list(set(dw).intersection(df['w']).difference(dt['w']))
         #HACK


### PR DESCRIPTION
Fixes an issue preventing the correct handling of multiple OSM patch files per tile due to an unwanted re-initialization of the patches_area variable after each iteration over patch files. Kudos to @melbo911.