### PR TITLE
Use '<authority>:<code>' preferred initialization method

### DIFF
--- a/src/O4_Geo_Utils.py
+++ b/src/O4_Geo_Utils.py
@@ -16,8 +16,8 @@ def dist(A,B):
     return 2*earth_radius*atan2(sqrt(a),sqrt(1-a))
 
 epsg={}
-epsg['4326']=pyproj.Proj(init='epsg:4326')
-epsg['3857']=pyproj.Proj(init='epsg:3857')
+epsg['4326']=pyproj.Proj('epsg:4326')
+epsg['3857']=pyproj.Proj('epsg:3857')
     
 
 ##############################################################################

--- a/src/O4_Geotag.py
+++ b/src/O4_Geotag.py
@@ -2,8 +2,8 @@ import os
 import pyproj
 from math import pi, exp, atan
 
-geographic=pyproj.Proj(init='epsg:4326')
-webmercator=pyproj.Proj(init='epsg:3857')
+geographic=pyproj.Proj('epsg:4326')
+webmercator=pyproj.Proj('epsg:3857')
 
 def gtile_to_wgs84(til_x,til_y,zoomlevel):
     rat_x=(til_x/(2**(zoomlevel-1))-1)

--- a/src/O4_Imagery_Utils.py
+++ b/src/O4_Imagery_Utils.py
@@ -96,11 +96,11 @@ def initialize_extents_dict():
                 # structuring data
                 if key=='epsg_code':
                     try:
-                        GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:'+value)
+                        GEO.epsg[value]=GEO.pyproj.Proj('epsg:'+value)
                     except:
                         # HACK for Slovenia 
                         if int(value)==102060:
-                            GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:3912')
+                            GEO.epsg[value]=GEO.pyproj.Proj('epsg:3912')
                         else:
                             print("Error in epsg code for extent",extent_code)
                             valid_extent=False
@@ -195,11 +195,11 @@ def initialize_providers_dict():
                         valid_provider=False
                 elif key=='epsg_code':
                     try:
-                        GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:'+value)
+                        GEO.epsg[value]=GEO.pyproj.Proj('epsg:'+value)
                     except:
                         # HACK for Slovenia 
                         if int(value)==102060:
-                            GEO.epsg[value]=GEO.pyproj.Proj(init='epsg:3912')
+                            GEO.epsg[value]=GEO.pyproj.Proj('epsg:3912')
                         else:
                             UI.vprint(0,"Error in epsg code for provider",provider_code)
                             valid_provider=False

--- a/src/O4_Mask_Utils.py
+++ b/src/O4_Mask_Utils.py
@@ -513,8 +513,8 @@ if __name__ == '__main__':
         print("Changing coordinates to match EPSG code")
         import pyproj
         import shapely.ops
-        s_proj=pyproj.Proj(init='epsg:4326')
-        t_proj=pyproj.Proj(init='epsg:'+epsg_code)
+        s_proj=pyproj.Proj('epsg:4326')
+        t_proj=pyproj.Proj('epsg:'+epsg_code)
         reprojection = lambda x, y: pyproj.transform(s_proj, t_proj, x, y)
         multipolygon_area=shapely.ops.transform(reprojection,multipolygon_area)
 


### PR DESCRIPTION
FutureWarning: '+init=<authority>:<code>' syntax is deprecated. '<authority>:<code>' is the preferred initialization method. When making the change, be mindful of axis order changes: https://pyproj4.github.io/pyproj/stable/gotchas.html#axis-order-changes-in-proj-6