### PR TITLE
install Python only if not yet installed

### DIFF
--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,12 +1,5 @@
-# Install Python if not found
-if command -v python3 &>/dev/null; then
-    echo "python3 already available"
-else
-    brew install python
-fi
-
 # Install dependencies
-brew install gdal spatialindex p7zip proj python-tk
+brew install gdal spatialindex p7zip proj
 
 # Install pyproj
 pip3 install pyproj

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,5 +1,12 @@
+# Install Python if not found
+if command -v python3 &>/dev/null; then
+    echo "python3 already available"
+else
+    brew install python
+fi
+
 # Install dependencies
-brew install python gdal spatialindex p7zip proj python-tk
+brew install gdal spatialindex p7zip proj python-tk
 
 # Install pyproj
 pip3 install pyproj


### PR DESCRIPTION
Closes #234 

Root cause: Python might be installed already by Xcode developer tools or other sources before