### PR TITLE
Add Setup and Start shell scripts for a virtual Python environment on Linux, add EOX with 2021 images as provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Tiles/
 **/*.bak
 **/*.swp
 .last_gui_params.txt
+z_Python_Venv

--- a/Providers/Global/EOX2-2021.lay
+++ b/Providers/Global/EOX2-2021.lay
@@ -1,0 +1,5 @@
+request_type=tms
+grid_type=webmercator
+url_template=https://{switch:a,b,c,d}.s2maps-tiles.eu/wmts/?layer=s2cloudless-2021_3857&style=default&tilematrixset=GoogleMapsCompatible&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={zoom}&TileCol={x}&TileRow={y}
+max_zl=14
+imagery_dir=grouped

--- a/requirements_nover.txt
+++ b/requirements_nover.txt
@@ -1,0 +1,11 @@
+certifi
+chardet
+idna
+numpy
+Pillow
+pyproj
+requests
+Rtree
+Shapely
+urllib3
+build

--- a/requirements_nover.txt
+++ b/requirements_nover.txt
@@ -9,3 +9,4 @@ Rtree
 Shapely
 urllib3
 build
+scikit-fmm

--- a/z_Install_Python_Venv.sh
+++ b/z_Install_Python_Venv.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+path="$PWD/z_Python_Venv"
+
+# 1. Create a Python virtual environment
+
+python -m venv $path
+
+# 2. Activate Python venv
+
+source $path/bin/activate
+
+# 3. Install packages with pip
+
+pip install -r $PWD/requirements_nover.txt
+
+# 4. Download scikit-fmm's "meson" branch, compile and install it
+
+git clone --branch meson https://github.com/scikit-fmm/scikit-fmm.git $path/scikit-fmm
+
+python -m build $path/scikit-fmm
+
+pip install $path/scikit-fmm
+
+# 6. DONE
+
+echo " "
+echo "Preparation complete!"
+echo " "
+echo "Use \"$path/bin/python $PWD/Ortho4XP\" to start O4XP"
+echo " "
+echo " "
+
+# Function: Pause
+function pause(){
+   read -p "$*"
+}
+
+pause "Press enter to continue... "

--- a/z_Install_Python_Venv.sh
+++ b/z_Install_Python_Venv.sh
@@ -14,15 +14,7 @@ source $path/bin/activate
 
 pip install -r $PWD/requirements_nover.txt
 
-# 4. Download scikit-fmm's "meson" branch, compile and install it
-
-git clone --branch meson https://github.com/scikit-fmm/scikit-fmm.git $path/scikit-fmm
-
-python -m build $path/scikit-fmm
-
-pip install $path/scikit-fmm
-
-# 6. DONE
+# 4. DONE
 
 echo " "
 echo "Preparation complete!"

--- a/z_Start_O4XP_PythonVenv.sh
+++ b/z_Start_O4XP_PythonVenv.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+path="$PWD/z_Python_Venv"
+
+$path/bin/python $PWD/Ortho4XP.py


### PR DESCRIPTION
This adds:

- A bash script to create a virtual Python environment in the O4XP folder. This is intended for some Linux distros like Arch Linux that are already using Python 3.12 by default and to work around current scikit-fmm versioning issues. The script will install all required PIP packages and download, compile and install scikit-fmm from a branch that works in 3.12.
- A bash script that will start O4XP in said virtual Linux environment.
- A modified requirements.txt that is not version locked.
- A new provider file for the superior 2021 imagery from EOX (as opposed to the default 2018 ones supplied by EOX2), see https://s2maps.eu/