### PR TITLE
Use Viewfinder Panoramas 1 arc second DEM data for New Zealand

### DIFF
--- a/src/O4_DEM_Utils.py
+++ b/src/O4_DEM_Utils.py
@@ -685,6 +685,11 @@ def ensure_elevation(source, lat, lon, verbose=True):
                 resol = 1
             else:
                 resol = 3
+
+            # Wellington Intl has missing elevation data in 1" resolution
+            if (lat, lon) == (-42, 174):
+                resol = 3
+
             url = (
                 "http://viewfinderpanoramas.org/dem"
                 + str(resol)

--- a/src/O4_DEM_Utils.py
+++ b/src/O4_DEM_Utils.py
@@ -671,6 +671,16 @@ def ensure_elevation(source, lat, lon, verbose=True):
                 "P36",
                 "Q36",
                 "R36",
+                # New Zealand
+                "SL58",
+                "SI59",
+                "SJ59",
+                "SK59",
+                "SL59",
+                "SI60",
+                "SJ60",
+                "SK60",
+                "SL60",
             ):
                 resol = 1
             else:


### PR DESCRIPTION
Viewfinder Panoramas provides 1 arc second DEMs for New Zealand.
Have a look at the [Coverage Map](https://viewfinderpanoramas.org/Coverage%20map%20viewfinderpanoramas_org1.htm)