### PR TITLE
add ability to set alternate custom_overlay_src

### DIFF
--- a/src/O4_Config_Utils.py
+++ b/src/O4_Config_Utils.py
@@ -113,6 +113,12 @@ a particular server.",
         "default": "",
         "hint": "The directory containing the sceneries with the overlays you would like to extract. You need to select the level of directory just _ABOVE_ Earth nav data.",
     },
+    "custom_overlay_src_alternate": {
+        "module": "OVL",
+        "type": str,
+        "default": "",
+        "hint": "If sceneries with overlays are not found in custom_overlay_src, set an alternate directory to search.",
+    },
     # Vector
     "apt_smoothing_pix": {
         "type": int,
@@ -366,9 +372,10 @@ list_app_vars = [
     "ovl_exclude_net",
     "custom_scenery_dir",
     "custom_overlay_src",
+    "custom_overlay_src_alternate"
 ]
-gui_app_vars_short = list_app_vars[:-2]
-gui_app_vars_long = list_app_vars[-2:]
+gui_app_vars_short = list_app_vars[:-3]
+gui_app_vars_long = list_app_vars[-3:]
 
 list_vector_vars = [
     "apt_smoothing_pix",

--- a/src/O4_Overlay_Utils.py
+++ b/src/O4_Overlay_Utils.py
@@ -13,6 +13,7 @@ ovl_exclude_net = []
 
 # the following is meant to be modified by the CFG module at run time
 custom_overlay_src = ""
+custom_overlay_src_alternate = ""
 
 if "dar" in sys.platform:
     unzip_cmd = "7z "
@@ -41,7 +42,13 @@ def build_overlay(lat, lon):
         custom_overlay_src,
         "Earth nav data",
         FNAMES.long_latlon(lat, lon) + ".dsf",
-    )
+        )
+    if not os.path.exists(file_to_sniff):
+        file_to_sniff = os.path.join(
+        custom_overlay_src_alternate,
+        "Earth nav data",
+        FNAMES.long_latlon(lat, lon) + ".dsf",
+        )
     if not os.path.exists(file_to_sniff):
         UI.exit_message_and_bottom_line(
             "   ERROR: file ",


### PR DESCRIPTION
I ran into [this issue](https://forums.x-plane.org/index.php?/forums/topic/267415-ortho4xp-v130-cant-extract-overlay/#comment-2365154) when trying to batch build some tiles and thought it would be helpful to have a way to search an alternate directory. 

The issue is the X-Plane default scenery files are split up between `/X-Plane 12/Global Scenery/X-Plane Global Scenery` **and** `/X-Plane 12/Global Scenery/X-Plane Demo Areas`. So if you set `custom_overlay_src` to the first directory and try to batch build a bunch of tiles, you might get an error that the .dsf file can't be found.

This adds the ability to set a new `custom_overlay_src_alternate` setting such that in the event the .dsf files are not found in `custom_overlay_src`, it will search this alternate directory.

<img width="1111" alt="Screenshot 2024-06-01 at 3 59 28 PM" src="https://github.com/oscarpilote/Ortho4XP/assets/32663154/a0a07bf5-cba9-4784-a1d1-749cd7bb8143">
